### PR TITLE
DNS Healthcheck Endpoint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
         GOOS: ["linux", "darwin", "windows"]
         GOARCH: ["amd64", "arm64"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build Binary
         env:
@@ -73,7 +73,7 @@ jobs:
       - installers
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container: golang:1
+    env:
+      GOFLAGS: "-buildvcs=false"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
       - name: Test
         run: make test

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,7 @@ func init() {
 		healthcheckPort  int
 		healthyThreshold time.Duration
 		logLevel         string
+		dnsHostname      string
 	)
 
 	cobra.OnInitialize(initConfig)
@@ -42,11 +43,13 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&healthcheckPort, "healthcheck-port", 9915, "The port the metrics server binds to")
 	rootCmd.PersistentFlags().DurationVar(&healthyThreshold, "healthcheck-threshold", 5*time.Minute, "Duration after which the healthchecks will switch to unhealthy")
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "How verbose the logs should be. panic, fatal, error, warn, info, debug, trace")
+	rootCmd.PersistentFlags().StringVar(&dnsHostname, "dns-hostname", "", "The hostname to check for DNS responses. Disabled if not provided.")
 
 	cobra.CheckErr(viper.BindPFlag("hostname", rootCmd.PersistentFlags().Lookup("hostname")))
 	cobra.CheckErr(viper.BindPFlag("healthcheck-port", rootCmd.PersistentFlags().Lookup("healthcheck-port")))
 	cobra.CheckErr(viper.BindPFlag("healthcheck-threshold", rootCmd.PersistentFlags().Lookup("healthcheck-threshold")))
 	cobra.CheckErr(viper.BindPFlag("log-level", rootCmd.PersistentFlags().Lookup("log-level")))
+	cobra.CheckErr(viper.BindPFlag("dns-hostname", rootCmd.PersistentFlags().Lookup("dns-hostname")))
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -27,6 +27,7 @@ var serveCmd = &cobra.Command{
 
 		// Run this in the background, so the metrics healthz endpoint can come up while waiting for Chia
 		go startWebsocket(h)
+		go h.DNSCheckLoop()
 
 		log.Fatalln(h.StartServer())
 	},

--- a/internal/healthcheck/dns.go
+++ b/internal/healthcheck/dns.go
@@ -1,0 +1,71 @@
+package healthcheck
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+// DNSCheckLoop runs a loop checking for DNS responses
+func (h *Healthcheck) DNSCheckLoop() {
+	hostname := viper.GetString("dns-hostname")
+	if len(hostname) == 0 {
+		return
+	}
+
+	r := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			d := net.Dialer{
+				Timeout: 30 * time.Second,
+			}
+			return d.DialContext(ctx, network, "127.0.0.1:53")
+		},
+	}
+
+	for {
+		func() {
+			ips, err := r.LookupIP(context.TODO(), "ip", hostname)
+			if err != nil {
+				log.Printf("Fetching dns records failed: %s\n", err.Error())
+				h.dnsOK = false
+				return
+			}
+
+			if len(ips) > 0 {
+				log.Println("Received at least 1 IP. Ready!")
+				h.dnsOK = true
+				return
+			}
+
+			log.Println("Received NO IPs. Not Ready!")
+			h.dnsOK = false
+		}()
+
+		time.Sleep(30 * time.Second)
+	}
+}
+
+// seederHealthcheck endpoint for the seeder service as a whole (Are we sending DNS responses)
+func (h *Healthcheck) seederHealthcheck() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if h.dnsOK {
+			w.WriteHeader(http.StatusOK)
+			_, err := fmt.Fprintf(w, "Ok")
+			if err != nil {
+				log.Errorf("Error writing healthcheck response %s\n", err.Error())
+			}
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, err := fmt.Fprintf(w, "Not OK")
+			if err != nil {
+				log.Errorf("Error writing healthcheck response %s\n", err.Error())
+			}
+		}
+	}
+}


### PR DESCRIPTION
Basically same logic from [here](https://github.com/Chia-Network/dns-introducer-healthcheck/blob/main/main.go), but doesn't take over TCP 53 in favor of this new package's pattern (endpoint for each service). 