### PR TITLE
Change default port

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,7 +40,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.chia-healthcheck.yaml)")
 
 	rootCmd.PersistentFlags().StringVar(&hostname, "hostname", "localhost", "The hostname to connect to")
-	rootCmd.PersistentFlags().IntVar(&healthcheckPort, "healthcheck-port", 9915, "The port the metrics server binds to")
+	rootCmd.PersistentFlags().IntVar(&healthcheckPort, "healthcheck-port", 9950, "The port the metrics server binds to")
 	rootCmd.PersistentFlags().DurationVar(&healthyThreshold, "healthcheck-threshold", 5*time.Minute, "Duration after which the healthchecks will switch to unhealthy")
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "How verbose the logs should be. panic, fatal, error, warn, info, debug, trace")
 	rootCmd.PersistentFlags().StringVar(&dnsHostname, "dns-hostname", "", "The hostname to check for DNS responses. Disabled if not provided.")

--- a/readme.md
+++ b/readme.md
@@ -44,9 +44,9 @@ sudo apt-get install chia-healthcheck
 
 First, install [chia-blockchain](https://github.com/Chia-Network/chia-blockchain). Chia healthcheck expects to be run on the same machine as the chia blockchain installation, and will use either the default chia config (`~/.chia/mainnet/`) or else the config located at `CHIA_ROOT`, if the environment variable is set.
 
-`chia-healthcheck serve` will start the healthcheck service on the default port of `9915`.
+`chia-healthcheck serve` will start the healthcheck service on the default port of `9950`.
 
-You can check the status of the full node at `<hostname>:9915/full_node`. A response code `200` indicates the full node is receiving new blocks, while a response code of `500` would indicate that a new block has not been received within the healthcheck interval (5 minutes by default).
+You can check the status of the full node at `<hostname>:9950/full_node`. A response code `200` indicates the full node is receiving new blocks, while a response code of `500` would indicate that a new block has not been received within the healthcheck interval (5 minutes by default).
 
 ### Configuration
 
@@ -57,5 +57,5 @@ To set a config value as an environment variable, prefix the name with `CHIA_HEA
 To use a config file, create a new yaml file and place any configuration options you want to specify in the file. The config file will be loaded by default from `~/.chia-healthcheck.yaml`, but the location can be overridden with the `--config` flag.
 
 ```yaml
-healthcheck-port: 9915
+healthcheck-port: 9950
 ```


### PR DESCRIPTION
9915 is the next port inline to logically use when running mulitple instances of chia-exporter (9914) Changing the default here so that there is less conflict by default