### PR TITLE
Add startup and liveness probe, change readiness probe

### DIFF
--- a/internal/healthcheck/healthcheck.go
+++ b/internal/healthcheck/healthcheck.go
@@ -21,6 +21,9 @@ type Healthcheck struct {
 	client          *rpc.Client
 	chiaConfig      *config.ChiaConfig
 
+	// Last time the full node was synced
+	lastSyncedTime time.Time
+
 	// Last block height we received
 	lastHeight uint32
 
@@ -88,7 +91,9 @@ func (h *Healthcheck) StartServer() error {
 	log.Printf("Starting healthcheck server on port %d", h.healthcheckPort)
 
 	http.HandleFunc("/full_node", h.fullNodeHealthcheck())
+	http.HandleFunc("/full_node/startup", h.fullNodeStartup())
 	http.HandleFunc("/full_node/readiness", h.fullNodeReadiness())
+	http.HandleFunc("/full_node/liveness", h.fullNodeLiveness())
 	http.HandleFunc("/seeder", h.seederHealthcheck())
 	http.HandleFunc("/seeder/readiness", h.seederReadiness())
 	http.HandleFunc("/timelord", h.timelordHealthcheck())


### PR DESCRIPTION
This adds two new endpoints and changes behavior on the /full_node/readiness endpoint. The new behavior is:

startup -> chain height is increasing
liveness -> chain height is increasing
readiness -> node is synced

In the context of kubernetes, the readiness endpoint would previously report ready if just the full_node's peer and RPC ports are listening, where we'd normally consider a full_node ready when it's synced.