### PR TITLE
Update Managed Files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,13 +62,16 @@ $(TEST_TARGETS): test
 check test tests: fmt lint vet staticcheck errcheck vulncheck; $(info $(M) running $(NAME:%=% )tests…) @ ## Run tests
 	$Q $(GO) test -timeout $(TIMEOUT)s $(ARGS) $(TESTPKGS)
 
-.PHONY: lint
-lint: | $(GOLINT) ; $(info $(M) running golint…) @ ## Run golint
-	$Q $(GOLINT) -set_exit_status $(PKGS)
-
 .PHONY: fmt
 fmt: ; $(info $(M) running gofmt…) @ ## Run gofmt on all source files
 	$Q $(GO) fmt $(PKGS)
+
+# Run fmt before any linter so parallel `-jN` doesn't change files while a linter is mid flight.
+lint vet staticcheck errcheck vulncheck: fmt
+
+.PHONY: lint
+lint: | $(GOLINT) ; $(info $(M) running golint…) @ ## Run golint
+	$Q $(GOLINT) -set_exit_status $(PKGS)
 
 .PHONY: vet
 vet: ; $(info $(M) running go vet…) @ ## Run go vet on all source files


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: Makefile-only dependency ordering change that just enforces formatting before linting/static analysis, primarily affecting build/test workflow in parallel runs.
> 
> **Overview**
> Ensures `fmt` runs *before* `lint`, `vet`, `staticcheck`, `errcheck`, and `vulncheck` by adding explicit Makefile dependencies, preventing parallel `make -jN` runs from mutating files while linters execute.
> 
> No functional code changes; this only adjusts the CI/local tooling order for formatting and static checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f48a2d7db09b49710abd03afae6528d8feb96282. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->